### PR TITLE
refactor: standardiser les imports pour améliorer la cohérence du code

### DIFF
--- a/src/components/dashboard/dashboard-items.tsx
+++ b/src/components/dashboard/dashboard-items.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { type SidebarSubNavItem } from "@/components/layout/dashboard-sidebar";
+import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Suspense } from "react";
-import { SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar";
 
 type DashboardItemsProps = {
   items: SidebarSubNavItem[];

--- a/src/components/layout/dashboard-header.tsx
+++ b/src/components/layout/dashboard-header.tsx
@@ -8,15 +8,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { authClient } from "@/lib/auth-client";
-import { prisma } from "@/lib/prisma";
 import { BellIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Separator } from "../ui/separator";
 
 export function DashboardHeader() {
   const router = useRouter();

--- a/src/components/layout/dashboard-sidebar.tsx
+++ b/src/components/layout/dashboard-sidebar.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { NavDocuments } from "@/components/nav-documents";
+import { NavMain } from "@/components/nav-main";
+import { NavSecondary } from "@/components/nav-secondary";
+import { NavUser } from "@/components/nav-user";
 import {
   Sidebar,
   SidebarContent,
@@ -26,10 +30,6 @@ import Link from "next/link";
 import { redirect, usePathname, useRouter } from "next/navigation";
 import { ComponentProps } from "react";
 import { toast } from "sonner";
-import { NavMain } from "../nav-main";
-import { NavDocuments } from "../nav-documents";
-import { NavSecondary } from "../nav-secondary";
-import { NavUser } from "../nav-user";
 
 export type SidebarSubNavItem = {
   label: string;

--- a/src/components/layout/mobile-menu.tsx
+++ b/src/components/layout/mobile-menu.tsx
@@ -4,14 +4,14 @@ import {
   LoginOrDashboardButton,
   type NavigationItem,
 } from "@/components/layout/header";
+import { NavigationItems } from "@/components/layout/navigation-items";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
+import { Separator } from "@/components/ui/separator";
 import { SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { authClient } from "@/lib/auth-client";
 import { CoinsIcon } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { Suspense, useState } from "react";
-import { Separator } from "../ui/separator";
-import { NavigationItems } from "./navigation-items";
 
 type MobileMenuProps = {
   navigationItems: NavigationItem[];

--- a/src/components/nav-documents.tsx
+++ b/src/components/nav-documents.tsx
@@ -7,6 +7,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 
+import { SidebarSubNavItem } from "@/components/layout/dashboard-sidebar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,7 +24,6 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { SidebarSubNavItem } from "./layout/dashboard-sidebar";
 
 export function NavDocuments({ items }: { items: SidebarSubNavItem[] }) {
   const { isMobile } = useSidebar();

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { IconCirclePlusFilled, IconPlus } from "@tabler/icons-react";
+import { IconPlus } from "@tabler/icons-react";
 
+import { DashboardItems } from "@/components/dashboard/dashboard-items";
+import { SidebarSubNavItem } from "@/components/layout/dashboard-sidebar";
+import { Button } from "@/components/ui/button";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -9,11 +12,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import Link from "next/link";
-import { DashboardItems } from "./dashboard/dashboard-items";
-import { SidebarSubNavItem } from "./layout/dashboard-sidebar";
-import { Button } from "./ui/button";
 import { DollarSignIcon } from "lucide-react";
+import Link from "next/link";
 
 export function NavMain({ items }: { items: SidebarSubNavItem[] }) {
   return (

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import { SidebarSubNavItem } from "@/components/layout/dashboard-sidebar";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -10,7 +11,6 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import Link from "next/link";
-import { SidebarSubNavItem } from "./layout/dashboard-sidebar";
 
 export function NavSecondary({
   items,

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -8,6 +8,7 @@ import {
   IconUserCircle,
 } from "@tabler/icons-react";
 
+import { UserSidebarNavItem } from "@/components/layout/dashboard-sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -27,7 +28,6 @@ import {
 import { authClient } from "@/lib/auth-client";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { UserSidebarNavItem } from "./layout/dashboard-sidebar";
 
 export function NavUser({ user }: { user: UserSidebarNavItem }) {
   const { isMobile } = useSidebar();

--- a/src/components/section-cards.tsx
+++ b/src/components/section-cards.tsx
@@ -1,5 +1,5 @@
+import { DashboardSectionCard } from "@/components/dashboard/dashboard-section-card";
 import { CreditCardIcon, DollarSignIcon } from "lucide-react";
-import { DashboardSectionCard } from "./dashboard/dashboard-section-card";
 
 export function SectionCards() {
   return (

--- a/src/components/tontines/invite-member-modal.tsx
+++ b/src/components/tontines/invite-member-modal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { InviteMemberForm } from "@/components/tontines/invite-member-form";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,7 +10,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useState } from "react";
-import { InviteMemberForm } from "./invite-member-form";
 
 type SignupModalProps = {
   triggerText?: string;

--- a/src/components/tontines/tontine-details.tsx
+++ b/src/components/tontines/tontine-details.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { InviteMemberForm } from "@/components/tontines/invite-member-form";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,6 +12,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import { TontineRole, TontineStatus } from "@prisma/client";
@@ -24,14 +32,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../ui/dialog";
-import { InviteMemberForm } from "./invite-member-form";
 
 type TontineFrequencyType =
   | "WEEKLY"

--- a/src/lib/email-templates/index.ts
+++ b/src/lib/email-templates/index.ts
@@ -2,6 +2,7 @@ import { missedPaymentTemplate } from "@/lib/email-templates/missed-payment";
 import { passwordResetTemplate } from "@/lib/email-templates/password-reset";
 import { paymentNotificationTemplate } from "@/lib/email-templates/payment-notification";
 import { registrationTemplate } from "@/lib/email-templates/registration";
+import { tontineCreatedTemplate } from "@/lib/email-templates/tontine-created";
 import { tontineInvitationTemplate } from "@/lib/email-templates/tontine-invitation";
 
 // Templates d'emails disponibles
@@ -11,6 +12,7 @@ export const emailTemplates = {
   passwordReset: passwordResetTemplate,
   paymentNotification: paymentNotificationTemplate,
   missedPayment: missedPaymentTemplate,
+  tontineCreated: tontineCreatedTemplate,
 };
 
 // Fonctions pour envoyer les emails avec les templates
@@ -49,6 +51,20 @@ export function getMissedPaymentHtml(variables: {
   dueDate: string;
 }): string {
   return missedPaymentTemplate(variables);
+}
+
+export function getTontineCreatedHtml(variables: {
+  userName: string;
+  tontineName: string;
+  tontineType: string;
+  startDate: string;
+  endDate: string;
+  frequency: string;
+  contributionAmount: string;
+  maxMembers: number;
+  tontineUrl: string;
+}): string {
+  return tontineCreatedTemplate(variables);
 }
 
 // Helper pour créer un layout HTML commun

--- a/src/lib/email-templates/tontine-created.ts
+++ b/src/lib/email-templates/tontine-created.ts
@@ -1,0 +1,52 @@
+import { createEmailLayout } from "@/lib/email-templates/index";
+
+type TontineCreatedTemplateVariables = {
+  userName: string;
+  tontineName: string;
+  tontineType: string;
+  startDate: string;
+  endDate: string;
+  frequency: string;
+  contributionAmount: string;
+  maxMembers: number;
+  tontineUrl: string;
+};
+
+export function tontineCreatedTemplate(
+  variables: TontineCreatedTemplateVariables,
+): string {
+  const content = `
+    <h2>Confirmation de création de tontine</h2>
+    <p>
+      Bonjour ${variables.userName},
+    </p>
+    <p>
+      Félicitations ! Votre tontine <strong>"${variables.tontineName}"</strong> a été créée avec succès sur {{siteName}}.
+    </p>
+    <div style="background-color: #f9f9f9; padding: 15px; border-radius: 5px; margin: 20px 0;">
+      <h3 style="margin-top: 0;">Détails de votre tontine</h3>
+      <p><strong>Nom :</strong> ${variables.tontineName}</p>
+      <p><strong>Type :</strong> ${variables.tontineType}</p>
+      <p><strong>Date de début :</strong> ${variables.startDate}</p>
+      <p><strong>Date de fin :</strong> ${variables.endDate}</p>
+      <p><strong>Fréquence :</strong> ${variables.frequency}</p>
+      <p><strong>Contribution par membre :</strong> ${variables.contributionAmount}</p>
+      <p><strong>Nombre maximum de membres :</strong> ${variables.maxMembers}</p>
+    </div>
+    <p>
+      Vous pouvez dès maintenant inviter des membres à rejoindre votre tontine et gérer les paramètres depuis votre espace personnel.
+    </p>
+    <p style="text-align: center;">
+      <a class="button" href="${variables.tontineUrl}">Accéder à ma tontine</a>
+    </p>
+    <p>
+      Si vous avez des questions concernant la gestion de votre tontine, n'hésitez pas à consulter notre centre d'aide ou à contacter notre service client.
+    </p>
+    <p>
+      Cordialement,<br>
+      L'équipe {{siteName}}
+    </p>
+  `;
+
+  return createEmailLayout(content);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
+import { format } from "date-fns";
+import { fr } from "date-fns/locale";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
@@ -15,15 +17,9 @@ export function formatCurrency(amount: number): string {
   }).format(amount);
 }
 
-/**
- * Formate une date au format localisé français
- */
+// Fonction utilitaire pour formater la date
 export function formatDate(date: Date): string {
-  return new Intl.DateTimeFormat("fr-FR", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  }).format(date);
+  return format(date, "dd MMMM yyyy", { locale: fr });
 }
 
 /**


### PR DESCRIPTION
- Corrigé le style des imports dans les composants pour suivre une structure cohérente
- Réorganisé les imports pour privilégier d'abord les imports de @/components, puis @/lib
- Remplacé les imports relatifs (../) par des imports absolus avec alias (@/)
- Ajouté une fonction getTontineCreatedHtml et son template pour les notifications
- Implémenté l'envoi d'email lors de la création d'une tontine
- Standardisé la fonction formatDate en utilisant date-fns

Cette refactorisation améliore la lisibilité du code et suit les conventions établies pour le projet, facilitant ainsi la maintenance à long terme.